### PR TITLE
docs: add Postman collection and unify visible language

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,31 +18,31 @@ API backend en Spring Boot que actua como proxy hacia [DiceBear](https://www.dic
 
 Pensado como proyecto de portfolio backend: pequeno en alcance, pero cuidado en arquitectura, testing, operabilidad y presentacion.
 
-## Preview
+## Vista previa
 
-### Avatar generation through the proxy
+### Generacion de avatar a traves del proxy
 
 ![Postman avatar response](docs/images/postman_avatar.png)
 
 ### Swagger UI
 
-Clean API contract for the avatar endpoint, including request parameters and response media type.
+Contrato de API limpio para el endpoint principal, incluyendo parametros y tipo de respuesta.
 
 ![Swagger UI screenshot](docs/images/swagger_capture.png)
 
 ### Actuator health
 
-Runtime visibility through Spring Boot Actuator health checks.
+Visibilidad basica del servicio mediante el health check de Spring Boot Actuator.
 
 ![Actuator health screenshot](docs/images/postman_actuator.png)
 
-## What this repository demonstrates
+## Que demuestra este repositorio
 
-- Backend integration with an external provider through a dedicated HTTP client.
-- Clear separation between controller, application service and infrastructure concerns.
-- Cache and retry patterns applied to a realistic API use case.
-- Deterministic automated testing without depending on external network access.
-- Operational basics such as health endpoints, metrics and CI verification.
+- Integracion backend con un proveedor externo a traves de un cliente HTTP dedicado.
+- Separacion clara entre controller, application service e infraestructura.
+- Uso de cache y retry sobre un caso de uso realista de API.
+- Testing automatizado determinista sin depender de red externa.
+- Bases de operabilidad como health checks, metricas y verificacion en CI.
 
 ## Que resuelve
 
@@ -90,6 +90,20 @@ Ejemplos:
 curl "http://localhost:8080/avatar/demo-user?style=bottts"
 curl "http://localhost:8080/avatar/demo-user?style=adventurer&size=64"
 ```
+
+## Coleccion de Postman
+
+El repositorio incluye una coleccion exportada de Postman para probar rapidamente los endpoints principales:
+
+- avatar por defecto
+- avatar con estilo
+- health check
+- metadata de la aplicacion
+- caso de error por estilo invalido
+
+Archivo:
+
+`docs/postman/spring-dicebear-proxy-cache.postman_collection.json`
 
 ## Endpoints utiles
 
@@ -183,6 +197,14 @@ mvn -B -ntp verify
 - La llamada al proveedor externo esta encapsulada para facilitar testing y evolucion futura.
 - Los errores del upstream se traducen a `502 Bad Gateway`, que es una semantica razonable para un proxy backend.
 - Actuator expone `health`, `info` y `metrics`, y `info` incluye metadata de build generada por Maven.
+
+## Como lo explicaria en entrevista
+
+- `WebClient`: desacopla la llamada al proveedor externo y facilita evolucion futura.
+- `Caffeine`: evita repetir llamadas iguales cuando el seed y el estilo se repiten.
+- `Resilience4j retry`: protege frente a fallos transitorios del upstream.
+- `WireMock`: permite tests fiables sin depender de internet ni del estado real de DiceBear.
+- `Actuator`: añade salud y metricas basicas para observabilidad del servicio.
 
 ## Objetivo del repositorio
 

--- a/docs/postman/spring-dicebear-proxy-cache.postman_collection.json
+++ b/docs/postman/spring-dicebear-proxy-cache.postman_collection.json
@@ -1,0 +1,123 @@
+{
+  "info": {
+    "_postman_id": "a6ce1da4-2c91-4b14-9e6f-9fc1cfd1db7d",
+    "name": "spring-dicebear-proxy-cache",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": "Coleccion de Postman para probar los endpoints principales del proyecto spring-dicebear-proxy-cache."
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:8080"
+    }
+  ],
+  "item": [
+    {
+      "name": "Avatar - estilo por defecto",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/avatar/testuser",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "avatar",
+            "testuser"
+          ]
+        },
+        "description": "Genera un avatar SVG usando el estilo por defecto."
+      },
+      "response": []
+    },
+    {
+      "name": "Avatar - estilo bottts",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/avatar/testuser?style=bottts",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "avatar",
+            "testuser"
+          ],
+          "query": [
+            {
+              "key": "style",
+              "value": "bottts"
+            }
+          ]
+        },
+        "description": "Genera un avatar SVG usando un estilo explicito."
+      },
+      "response": []
+    },
+    {
+      "name": "Actuator - health",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/actuator/health",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "actuator",
+            "health"
+          ]
+        },
+        "description": "Comprueba el estado basico del servicio."
+      },
+      "response": []
+    },
+    {
+      "name": "Actuator - info",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/actuator/info",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "actuator",
+            "info"
+          ]
+        },
+        "description": "Devuelve metadata basica de build y aplicacion."
+      },
+      "response": []
+    },
+    {
+      "name": "Avatar - estilo invalido",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{baseUrl}}/avatar/testuser?style=bad/style",
+          "host": [
+            "{{baseUrl}}"
+          ],
+          "path": [
+            "avatar",
+            "testuser"
+          ],
+          "query": [
+            {
+              "key": "style",
+              "value": "bad/style"
+            }
+          ]
+        },
+        "description": "Ejemplo de validacion fallida para comprobar la respuesta 400."
+      },
+      "response": []
+    }
+  ]
+}

--- a/src/main/java/com/jesus/dicebearproxy/AvatarController.java
+++ b/src/main/java/com/jesus/dicebearproxy/AvatarController.java
@@ -34,16 +34,16 @@ public class AvatarController {
     }
 
     @Operation(
-            summary = "Generate avatar SVG through DiceBear proxy",
-            description = "Returns an SVG avatar generated from the provided seed. "
-                    + "If style is not provided, the default style is adventurer.")
+            summary = "Genera un avatar SVG a traves del proxy DiceBear",
+            description = "Devuelve un avatar SVG generado a partir del seed indicado. "
+                    + "Si no se informa el estilo, se usa adventurer por defecto.")
     @GetMapping(value = "/{seed}", produces = "image/svg+xml")
     public ResponseEntity<byte[]> getAvatar(
-            @Parameter(description = "Unique avatar seed", example = "testuser")
+            @Parameter(description = "Seed unico para generar el avatar", example = "testuser")
             @PathVariable
             @Size(min = 1, max = 100, message = "seed must be between 1 and 100 characters")
             String seed,
-            @Parameter(description = "DiceBear style", example = "bottts")
+            @Parameter(description = "Estilo de DiceBear", example = "bottts")
             @RequestParam(name = "style", required = false)
             @Pattern(
                     regexp = "^[a-zA-Z0-9-]{1,40}$",


### PR DESCRIPTION
## Summary

This PR closes the final presentation and usability gaps in the repository.

## Changes

- Added an exported Postman collection for the main API flows
- Improved README consistency in visible language and structure
- Added a short section to explain the project in interview terms
- Aligned Swagger-visible endpoint text with the rest of the repository presentation

## Why

The goal is to leave the repository easier to explore, easier to test manually and more coherent as a backend portfolio project.